### PR TITLE
Game Balancing

### DIFF
--- a/Assets/Prefabs/ExampleTower.prefab
+++ b/Assets/Prefabs/ExampleTower.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   radius: 7
-  fireInterval: 1
+  fireInterval: 1.5
   fireSpeed: 50
   damage: 1
   projectile: {fileID: 7488368378861601245, guid: c558fa4cbbfcd436ebbd81485b618758, type: 3}
@@ -125,13 +125,13 @@ MonoBehaviour:
   - key: 0
     value:
     - cost: 0
-      value: 1
+      value: 1.5
     - cost: 10
-      value: 0.9
+      value: 1.3
     - cost: 15
-      value: 0.8
+      value: 1.1
     - cost: 20
-      value: 0.7
+      value: 0.9
   - key: 1
     value:
     - cost: 0

--- a/Assets/Prefabs/GiantGoblin.prefab
+++ b/Assets/Prefabs/GiantGoblin.prefab
@@ -629,6 +629,9 @@ MonoBehaviour:
   maxHealth: 20
   lootPrefab: {fileID: 4729912602369655075, guid: 83ddec07a83ea46479fd3b6b726c8bbd, type: 3}
   deathSFX: {fileID: 8300000, guid: 781db39cb3a8849749aab2212ca343e6, type: 3}
+  minDropVal: 15
+  maxDropVal: 30
+  dropRate: 15
 --- !u!65 &2232300842511329412
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Skeleton.prefab
+++ b/Assets/Prefabs/Skeleton.prefab
@@ -617,9 +617,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a4d9724fc5a6549caafc6c75ec4a0b1c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 5
+  maxHealth: 8
   lootPrefab: {fileID: 4729912602369655075, guid: 83ddec07a83ea46479fd3b6b726c8bbd, type: 3}
   deathSFX: {fileID: 8300000, guid: 781db39cb3a8849749aab2212ca343e6, type: 3}
+  minDropVal: 1
+  maxDropVal: 15
+  dropRate: 10
 --- !u!65 &479696039374837172
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -9,6 +9,10 @@ public class EnemyBehavior : MonoBehaviour
     public GameObject lootPrefab;
     public AudioClip deathSFX;
 
+    public int minDropVal;
+    public int maxDropVal;
+    public int dropRate; // Higher = higher chance of dropping
+
     Animator animator;
     FollowPath followPath;
     HealthBar healthBar;
@@ -45,8 +49,14 @@ public class EnemyBehavior : MonoBehaviour
     void Die()
     {
         animator.SetTrigger("Death_b");
+
         followPath.SetSpeed(0);
         GetComponent<Collider>().enabled = false;
+
+        PickupBehavior pickup = lootPrefab.GetComponent<PickupBehavior>();
+        pickup.minVal = minDropVal;
+        pickup.maxVal = maxDropVal;
+
         Invoke("DestroyEnemy", 2.5f);
         FindObjectOfType<LevelManager>().EnemyDestroyed();
         AudioSource.PlayClipAtPoint(deathSFX, transform.position);
@@ -54,9 +64,9 @@ public class EnemyBehavior : MonoBehaviour
 
     void DestroyEnemy()
     {
-        int dropRate = Random.Range(0, 6);
+        int dropVal = Random.Range(0, dropRate);
 
-        if (dropRate > 3)
+        if (dropVal > 3)
         {
             Instantiate(lootPrefab, transform.position, transform.rotation);
         }


### PR DESCRIPTION
Summary of changes:

- Skeleton health: 5 -> 7
- Starting money: 10 -> 15
- Drop rate increased for skeletons slightly
- Drop rate doubled for larger monsters
- Normal tower fire rate: 1 -> 1.5 (scales down by .2 per upgrade)
- Increased loot drop value for larger monster (15 - 30)
- Adjusted skeleton drop value (1 - 15 | -> | 5 -> 15)

Purpose of changes:
Skeletons were dying really quickly in all levels, so skeleton health was increased. 
With skeleton health increase and reduced starting money per round, drop rates and drop value was increased so that player can place more towers (more fun)
Reduced tower fire rate to increase difficulty
Drop rate and value adjusted for large monster (larger monster, better reward)

The game should now be difficult enough to require continous effort and new towers placed, but not hard enough that it is impossible. 